### PR TITLE
Add length tracking for normalized vectors

### DIFF
--- a/tests/cpp/getUnormalized_test.cpp
+++ b/tests/cpp/getUnormalized_test.cpp
@@ -1,0 +1,96 @@
+#include "../../hnswlib/hnswlib.h"
+
+#include <assert.h>
+
+#include <vector>
+#include <iostream>
+
+namespace {
+
+using idx_t = hnswlib::labeltype;
+
+void testReadUnormalizedData() {
+    int d = 4;
+    idx_t n = 100;
+    idx_t nq = 10;
+    size_t k = 10;
+
+    std::vector<float> data(n * d);
+
+    std::mt19937 rng;
+    rng.seed(47);
+    std::uniform_real_distribution<> distrib;
+
+    for (idx_t i = 0; i < n * d; ++i) {
+        data[i] = distrib(rng);
+    }
+
+    hnswlib::InnerProductSpace space(d);
+    hnswlib::HierarchicalNSW<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, 2 * n, 16, 200, 100, false, true);
+
+    for (size_t i = 0; i < n; ++i) {
+        alg_hnsw->addPoint(data.data() + d * i, i);
+    }
+
+    // Check that all data is the same
+    for (size_t i = 0; i < n; i++) {
+        std::vector<float> actual = alg_hnsw->template getDataByLabel<float>(i);
+        for (size_t j = 0; j < d; j++) {
+            // Check that abs difference is less than 1e-6
+            assert(std::abs(actual[j] - data[d * i + j]) < 1e-6);
+        }
+    }
+
+    delete alg_hnsw;
+}
+
+void testSaveAndLoadUnormalizedData() {
+    int d = 4;
+    idx_t n = 100;
+    idx_t nq = 10;
+    size_t k = 10;
+
+    std::vector<float> data(n * d);
+
+    std::mt19937 rng;
+    rng.seed(47);
+    std::uniform_real_distribution<> distrib(10.0, 15.0);
+
+    for (idx_t i = 0; i < n * d; ++i) {
+        data[i] = distrib(rng);
+    }
+
+    hnswlib::InnerProductSpace space(d);
+    hnswlib::HierarchicalNSW<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, 2 * n, 16, 200, 100, false, true);
+
+    for (size_t i = 0; i < n; ++i) {
+        alg_hnsw->addPoint(data.data() + d * i, i);
+    }
+
+    alg_hnsw->saveIndex("test.bin");
+
+    hnswlib::HierarchicalNSW<float>* alg_hnsw2 = new hnswlib::HierarchicalNSW<float>(&space, "test.bin", false, 2 * n, false, true);
+
+    // Check that all data is the same
+    for (size_t i = 0; i < n; i++) {
+        std::vector<float> actual = alg_hnsw2->template getDataByLabel<float>(i);
+        for (size_t j = 0; j < d; j++) {
+            // Check that abs difference is less than 1e-6
+            assert(std::abs(actual[j] - data[d * i + j]) < 1e-6);
+        }
+    }
+
+    delete alg_hnsw;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "Testing ..." << std::endl;
+    testReadUnormalizedData();
+    std::cout << "Test testReadUnormalizedData ok" << std::endl;
+    testSaveAndLoadUnormalizedData();
+    std::cout << "Test testSaveAndLoadUnormalizedData ok" << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
We'd like hnswlib to be able to return the un-normalized vectors when using cosine distance so that we don't have to do a join across the index and a separate storage of the un-normalized vectors . Rather than store the vectors in full resolution (which increases storage usage) or normalizing them in the distance computation (negative impact on performance) we choose to store their lengths and then when fetched, return the un-normalized vectors by recomputing them. 

- [x] Add path
- [ ] Update path
- [ ] Delete path
- [ ] Python bindings
- [x] Save / Load Path
- [x] Tests