### PR TITLE
File handle management

### DIFF
--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -921,7 +921,7 @@ PYBIND11_PLUGIN(hnswlib) {
             py::arg("is_persistent_index") = false)
         .def("persist_dirty", &Index<float>::persistDirty)
         .def("open_file_handles", &Index<float>::openFileHandles)
-        .def("close_file_handles ", &Index<float>::closeFileHandles)
+        .def("close_file_handles", &Index<float>::closeFileHandles)
         .def("mark_deleted", &Index<float>::markDeleted, py::arg("label"))
         .def("unmark_deleted", &Index<float>::unmarkDeleted, py::arg("label"))
         .def("resize_index", &Index<float>::resizeIndex, py::arg("new_size"))


### PR DESCRIPTION
We keep file handles open for the lifetime of an index, this can exhaust system file descriptor limits in the case of large numbers of indexes on systems with low file descriptor limits. This PR adds a way to open/close the needed file descriptors for calling python code to manage overall file handle usage across indexes.