### PR TITLE
Include binary wheels in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           CIBW_ARCHS_WINDOWS: "AMD64"
           CIBW_ARCHS_LINUX: "x86_64 aarch64"
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: python-package-distributions
           path: dist
@@ -54,7 +54,7 @@ jobs:
         python -m pip install .
         make dist
     - name: Download wheels
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: python-package-distributions
         path: dist/
@@ -62,7 +62,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
     # - name: Publish to PyPI
     #   uses: pypa/gh-action-pypi-publish@release/v1
     #   with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository-url: https://test.pypi.org/legacy/
-    # - name: Publish to PyPI
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   tests:
-    uses: ./.github/workflows/build.yml
+    uses: .github/workflows/test.yml
 
   build:
     needs: [tests]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,25 @@
-name: Build Wheels
+name: Release
 
 on:
   push:
-    branches:
-      - lukev/wheels
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]*'
 
 jobs:
+
+  tests:
+    uses: ./.github/workflows/build.yml
+
   build:
+    needs: [tests]
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - name: Install qemu
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
         if: matrix.os == 'ubuntu-latest'
-        # https://github.com/multiarch/qemu-user-static
-        run: |
-          sudo apt-get update
-          sudo apt-get install qemu binfmt-support qemu-user-static
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
@@ -33,7 +34,6 @@ jobs:
           CIBW_SKIP: "cp312-* pp* *musllinux*"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_WINDOWS: "AMD64"
-          # CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_LINUX: "x86_64 aarch64"
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
@@ -63,3 +63,7 @@ jobs:
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
+    # - name: Publish to PyPI
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   tests:
-    uses: .github/workflows/test.yml
+    uses: ./.github/workflows/test.yml
 
   build:
     needs: [tests]

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -10,15 +10,16 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - name: Install qemu
-        if: matrix.os == 'ubuntu-latest'
-        # https://github.com/multiarch/qemu-user-static
-        run: |
-          sudo apt-get update
-          sudo apt-get install qemu binfmt-support qemu-user-static
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      # temporarily removing qemu: emulated build takes at least two hours
+      # - name: Install qemu
+      #   if: matrix.os == 'ubuntu-latest'
+      #   # https://github.com/multiarch/qemu-user-static
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install qemu binfmt-support qemu-user-static
+      #     docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
       - name: Install cibuildwheel
@@ -31,7 +32,8 @@ jobs:
           CIBW_SKIP: "cp312-* pp*"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_WINDOWS: "AMD64"
-          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+          CIBW_ARCHS_LINUX: "x86_64"
+          # CIBW_ARCHS_LINUX: "x86_64 aarch64"
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -1,9 +1,10 @@
 name: Build Wheels
 
 jobs:
-  on: push:
-    branches:
-      - lukev/wheels
+  on:
+    push:
+      branches:
+        - lukev/wheels
 
   build:
     runs-on: ${{matrix.os}}

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -21,3 +21,8 @@ jobs:
         run: |
           pip install build
           python -m build --wheel
+          - name: Publish to Test PyPI
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -50,7 +50,9 @@ jobs:
       with:
         python-version: "3.10"
     - name: Build sdist
-      run: make dist
+      run: |
+        python -m pip install .
+        make dist
     - name: Download wheels
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -11,19 +11,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-        with:
-          python-version: ${{matrix.python-version}}
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
-
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
         env:
           HNSWLIB_NO_NATIVE: true
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -1,11 +1,11 @@
 name: Build Wheels
 
-jobs:
-  on:
-    push:
-      branches:
-        - lukev/wheels
+on:
+  push:
+    branches:
+      - lukev/wheels
 
+jobs:
   build:
     runs-on: ${{matrix.os}}
     strategy:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -12,14 +12,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      # temporarily removing qemu: emulated build takes at least two hours
-      # - name: Install qemu
-      #   if: matrix.os == 'ubuntu-latest'
-      #   # https://github.com/multiarch/qemu-user-static
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install qemu binfmt-support qemu-user-static
-      #     docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - name: Install qemu
+        if: matrix.os == 'ubuntu-latest'
+        # https://github.com/multiarch/qemu-user-static
+        run: |
+          sudo apt-get update
+          sudo apt-get install qemu binfmt-support qemu-user-static
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -24,7 +24,7 @@ jobs:
           CIBW_SKIP: "cp312-* pp*"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_WINDOWS: "AMD64"
-          CIBW_ARCHS_LINUX: "x86_64 AARCH64"
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Install qemu
         if: matrix.os == 'ubuntu-latest'
-        run:
-          # https://github.com/multiarch/qemu-user-static
-          - "sudo apt-get install qemu binfmt-support qemu-user-static"
-          - "docker run --rm --privileged multiarch/qemu-user-static --reset -p yes"
+        # https://github.com/multiarch/qemu-user-static
+        run: |
+          sudo apt-get install qemu binfmt-support qemu-user-static
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
       - name: Install cibuildwheel

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -17,12 +17,13 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{matrix.python-version}}
-      - run: "export HNSWLIB_NO_NATIVE=true"
-        if: matrix.os == 'ubuntu-latest'
-      - name: Build
-        run: |
-          pip install build
-          python -m build --wheel
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir dist
+        env:
+          HNSWLIB_NO_NATIVE: true
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -16,6 +16,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         # https://github.com/multiarch/qemu-user-static
         run: |
+          sudo apt-get update
           sudo apt-get install qemu binfmt-support qemu-user-static
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - uses: actions/checkout@v3

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -34,8 +34,8 @@ jobs:
           CIBW_SKIP: "cp312-* pp*"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_WINDOWS: "AMD64"
-          CIBW_ARCHS_LINUX: "x86_64"
-          # CIBW_ARCHS_LINUX: "x86_64 aarch64"
+          # CIBW_ARCHS_LINUX: "x86_64"
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           HNSWLIB_NO_NATIVE: true
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
-          CIBW_SKIP: "cp312-* pp*"
+          CIBW_SKIP: "cp312-* pp* *musllinux*"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_WINDOWS: "AMD64"
           # CIBW_ARCHS_LINUX: "x86_64"

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -17,12 +17,35 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{matrix.python-version}}
+      - run: "export HNSWLIB_NO_NATIVE=true"
+        if: matrix.os == 'ubuntu-latest'
       - name: Build
         run: |
           pip install build
           python -m build --wheel
-      - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          name: python-package-distributions
+          path: dist
+
+  upload:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Build sdist
+      run: make dist
+    - name: Download wheels
+      uses: actions/download-artifact@v2
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -19,6 +19,6 @@ jobs:
           python-version: ${{matrix.python-version}}
       - name: Build
         run: |
-          rm dist/*
+          rm -rf dist/*
           pip install build
           python -m build --wheel

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -19,6 +19,5 @@ jobs:
           python-version: ${{matrix.python-version}}
       - name: Build
         run: |
-          rm -rf dist/*
           pip install build
           python -m build --wheel

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -21,8 +21,8 @@ jobs:
         run: |
           pip install build
           python -m build --wheel
-          - name: Publish to Test PyPI
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -22,6 +22,8 @@ jobs:
       #     docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.15.0
       - name: Build wheels

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -21,7 +21,10 @@ jobs:
         env:
           HNSWLIB_NO_NATIVE: true
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
-          CIBW_SKIP: cp312-*
+          CIBW_SKIP: "cp312-* pp*"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_WINDOWS: "AMD64"
+          CIBW_ARCHS_LINUX: "x86_64 AARCH64"
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -1,0 +1,19 @@
+name: Build Wheels
+
+jobs:
+  build:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.7"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{matrix.python-version}}
+      - name: Build
+        run: |
+          rm dist/*
+          pip install build
+          python -m build --wheel

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -1,7 +1,7 @@
 name: Build Wheels
 
 jobs:
-  on: push
+  on: push:
     branches:
       - lukev/wheels
 

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           HNSWLIB_NO_NATIVE: true
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
-          CIBW_SKIP: 'cp312-*"
+          CIBW_SKIP: cp312-*
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel
+        run: python -m pip install cibuildwheel==2.15.0
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
         env:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -12,6 +12,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
+      - name: Install qemu
+        if: matrix.os == 'ubuntu-latest'
+        run:
+          # https://github.com/multiarch/qemu-user-static
+          - "sudo apt-get install qemu binfmt-support qemu-user-static"
+          - "docker run --rm --privileged multiarch/qemu-user-static --reset -p yes"
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
       - name: Install cibuildwheel

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -21,6 +21,7 @@ jobs:
         env:
           HNSWLIB_NO_NATIVE: true
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
+          CIBW_SKIP: 'cp312-*"
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -1,6 +1,10 @@
 name: Build Wheels
 
 jobs:
+  on: push
+    branches:
+      - lukev/wheels
+
   build:
     runs-on: ${{matrix.os}}
     strategy:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
-name: HNSW CI
+name: Test
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_call]
 
 jobs:
   test_python:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Test
 
-on: [push, pull_request, workflow_call]
+on:
+  worfklow_call:
+  push:
+    branch: master
+  pull_request:
+    branch: master
 
 jobs:
   test_python:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 
 on:
-  worfklow_call:
+  workflow_call:
   push:
     branch: master
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,11 @@ name: Test
 on:
   workflow_call:
   push:
-    branch: master
+    branches:
+      - master
   pull_request:
-    branch: master
+    branches:
+      - master
 
 jobs:
   test_python:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ var/
 .vscode/
 .vs/
 **.DS_Store
+*.egg-info/
+venv/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Wheels are automatically built and pushed to PyPI for multiple
 platforms via GitHub actions using the
 [cibuildwheel](https://github.com/pypa/cibuildwheel).
 
+The `Publish` Github Action is configured to run whenever a version
+tag (a tag string with three period-delimited numbers) is pushed. Is
+is necessary to ensure that the version number in `setup.py` has also
+been updated, or else the `Publish` action will fail.
+
 ### Building AVX Extensions
 
 For maximum compatibility, the distributed wheels are not compiled to

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # Chroma-Hnswlib - fast approximate nearest neighbor search
 Chromas fork of https://github.com/nmslib/hnswlib
+
+## Build & Release
+
+Wheels are automatically built and pushed to PyPI for multiple
+platforms via GitHub actions using the
+[cibuildwheel](https://github.com/pypa/cibuildwheel).
+
+### Building AVX Extensions
+
+For maximum compatibility, the distributed wheels are not compiled to
+make use of Advanced Vector Extensions (AVX). If your hardware
+supports AVX, you may get better performance by recompiling this
+library on the machine on which it is intended to run.
+
+To force recompilation when installing, specify the `--no-binary
+chroma-hsnwlib` option to PIP when installing dependencies. This can
+be added to your `pip install` command, for example:
+
+```
+pip install -r requirements.txt --no-binary chroma-hnswlib
+```
+
+You can also put the `--no-binary` directive [in your requirements.txt](https://pip.pypa.io/en/stable/cli/pip_install/#install-no-binary).
+
+If you've already installed dependencies, you must first uninstall
+`chroma-hsnwlib` using `pip uninstall chroma-hnswlib` to remove the
+precompiled version before reinstalling.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import setuptools
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-__version__ = '0.7.3.alpha3'
+__version__ = '0.7.3.alpha4'
 
 include_dirs = [
     pybind11.get_include(),

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import setuptools
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-__version__ = '0.7.3.alpha2'
+__version__ = '0.7.3.alpha3'
 
 include_dirs = [
     pybind11.get_include(),

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import setuptools
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-__version__ = '0.7.3.alpha1'
+__version__ = '0.7.3.alpha2'
 
 include_dirs = [
     pybind11.get_include(),

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import setuptools
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-__version__ = '0.7.3.alpha6'
+__version__ = '0.7.3.alpha7'
 
 include_dirs = [
     pybind11.get_include(),

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import setuptools
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-__version__ = '0.7.2'
+__version__ = '0.7.3.alpha1'
 
 include_dirs = [
     pybind11.get_include(),

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import setuptools
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-__version__ = '0.7.3.alpha5'
+__version__ = '0.7.3.alpha6'
 
 include_dirs = [
     pybind11.get_include(),

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import setuptools
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-__version__ = '0.7.3.alpha4'
+__version__ = '0.7.3.alpha5'
 
 include_dirs = [
     pybind11.get_include(),


### PR DESCRIPTION
This PR builds binary wheels for the following platforms:

- Windows amd64 (AMD & Intel processors)
- Linux amd64 and arm64 (manylinux)
- Intel and Apple Silicon OSX

Note that 32 bit binaries are not included, as they caused the build to take 10x as long due to the emulation required. Distributions are also only for standard CPython, PyPy binaries are not included. Most linux distros will work with the manylinux build but a few (e.g Alpine) will not.

See the readme for instructions on how to rebuild for AVX support and what the release process for this repo is. 

Note that the code to deploy to production PyPI is commented out, it will need to be enabled after adding the appropriate token to this repo's secrets.

Fixes https://github.com/chroma-core/chroma/issues/885 and https://github.com/chroma-core/chroma/issues/993
