### PR TITLE
Use correct flags to disable AVX support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
         env:
-          HNSWLIB_NO_NATIVE: true
+          CIBW_ENVIRONMENT: HNSWLIB_NO_NATIVE=true
+          CIBW_ENVIRONMENT_PASS_LINUX: HNSWLIB_NO_NATIVE
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
           CIBW_SKIP: "cp312-* pp* *musllinux*"
           CIBW_ARCHS_MACOS: "x86_64 arm64"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import setuptools
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-__version__ = '0.7.3.alpha7'
+__version__ = '0.7.3.alpha8'
 
 include_dirs = [
     pybind11.get_include(),


### PR DESCRIPTION
Needed to use a separate configuration option to correctly pass environment variables to the *actual* build env in `cibuildwheel`.