### PR TITLE
use correct flag on ppc64le

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,10 @@ class BuildExt(build_ext):
         c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
         link_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
     else:
+        import subprocess
+        if subprocess.check_output(['uname', '-p']).decode('utf-8').strip() == 'ppc64le':
+            c_opts['unix'].remove('-march=native')
+            c_opts['unix'].append('-mcpu=native')
         c_opts['unix'].append("-fopenmp")
         link_opts['unix'].extend(['-fopenmp', '-pthread'])
 


### PR DESCRIPTION
Currently, the build for hnswlib fails on ppc64le as the compiler flag `-march=native` is unknown. The equivalent on ppc64le is `-mcpu=native`. This PR fixes this issue, hence, makes ChromaDB usable on ppc64le.