### PR TITLE
[ENH] Dynamic ef_search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,15 @@ add_library(hnswlib INTERFACE)
 target_include_directories(hnswlib INTERFACE .) 
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
     if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-      SET( CMAKE_CXX_FLAGS "-Ofast -DNDEBUG -std=c++11 -DHAVE_CXX0X -openmp -march=native -fpic -ftree-vectorize")
+      SET( CMAKE_CXX_FLAGS "-Ofast -DNDEBUG -std=c++17 -DHAVE_CXX0X -openmp -march=native -fpic -ftree-vectorize")
     elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      SET( CMAKE_CXX_FLAGS  "-Ofast -lrt -DNDEBUG -std=c++11 -DHAVE_CXX0X -march=native -fpic -w -fopenmp -ftree-vectorize -ftree-vectorizer-verbose=0" )
+      SET( CMAKE_CXX_FLAGS  "-Ofast -lrt -DNDEBUG -std=c++17 -DHAVE_CXX0X -march=native -fpic -w -fopenmp -ftree-vectorize -ftree-vectorizer-verbose=0" )
     elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-      SET( CMAKE_CXX_FLAGS  "-Ofast -lrt -DNDEBUG -std=c++11 -DHAVE_CXX0X -openmp -march=native -fpic -w -fopenmp -ftree-vectorize" )
+      SET( CMAKE_CXX_FLAGS  "-Ofast -lrt -DNDEBUG -std=c++17 -DHAVE_CXX0X -openmp -march=native -fpic -w -fopenmp -ftree-vectorize" )
     endif()
 
     # examples

--- a/TESTING_RECALL.md
+++ b/TESTING_RECALL.md
@@ -59,7 +59,7 @@ bf_index.init_index(max_elements=num_elements)
 
 # Controlling the recall for hnsw by setting ef:
 # higher ef leads to better accuracy, but slower search
-hnsw_index.set_ef(200)
+hnsw_index.set_ef_search_default(200)
 
 # Set number of threads used during batch search/construction in hnsw
 # By default using all available cores

--- a/examples/cpp/EXAMPLES.md
+++ b/examples/cpp/EXAMPLES.md
@@ -134,10 +134,11 @@ int main() {
     int M = 16;                 // Tightly connected with internal dimensionality of the data
                                 // strongly affects the memory consumption
     int ef_construction = 200;  // Controls index search speed/build speed tradeoff
+    int ef_search_default = 10  // Controls index search speed tradeoff
 
     // Initing index
     hnswlib::L2Space space(dim);
-    hnswlib::HierarchicalNSW<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements, M, ef_construction, 100, true);
+    hnswlib::HierarchicalNSW<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements, M, ef_construction, ef_search_default, 100, true);
 
     // Generate random data
     std::mt19937 rng;

--- a/examples/cpp/example_mt_replace_deleted.cpp
+++ b/examples/cpp/example_mt_replace_deleted.cpp
@@ -69,17 +69,18 @@ inline void ParallelFor(size_t start, size_t end, size_t numThreads, Function fn
 
 int main()
 {
-    int dim = 16;              // Dimension of the elements
-    int max_elements = 10000;  // Maximum number of elements, should be known beforehand
-    int M = 16;                // Tightly connected with internal dimensionality of the data
-                               // strongly affects the memory consumption
-    int ef_construction = 200; // Controls index search speed/build speed tradeoff
-    int num_threads = 20;      // Number of threads for operations with index
+    int dim = 16;               // Dimension of the elements
+    int max_elements = 10000;   // Maximum number of elements, should be known beforehand
+    int M = 16;                 // Tightly connected with internal dimensionality of the data
+                                // strongly affects the memory consumption
+    int ef_construction = 200;  // Controls index search speed/build speed tradeoff
+    int ef_search_default = 10; // Controls index search speed/recall tradeoff
+    int num_threads = 20;       // Number of threads for operations with index
 
     // Initing index with allow_replace_deleted=true
     int seed = 100;
     hnswlib::L2Space space(dim);
-    hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements, M, ef_construction, seed, true);
+    hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements, M, ef_construction, ef_search_default, seed, true);
 
     // Generate random data
     std::mt19937 rng;

--- a/examples/cpp/example_replace_deleted.cpp
+++ b/examples/cpp/example_replace_deleted.cpp
@@ -7,11 +7,12 @@ int main()
     int M = 16;                // Tightly connected with internal dimensionality of the data
                                // strongly affects the memory consumption
     int ef_construction = 200; // Controls index search speed/build speed tradeoff
+    int ef_search_default = 10;
 
     // Initing index with allow_replace_deleted=true
     int seed = 100;
     hnswlib::L2Space space(dim);
-    hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements, M, ef_construction, seed, true);
+    hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements, M, ef_construction, ef_search_default, seed, true);
 
     // Generate random data
     std::mt19937 rng;

--- a/examples/python/EXAMPLES.md
+++ b/examples/python/EXAMPLES.md
@@ -23,7 +23,7 @@ p.init_index(max_elements = num_elements, ef_construction = 200, M = 16)
 p.add_items(data, ids)
 
 # Controlling the recall by setting ef:
-p.set_ef(50) # ef should always be > k
+p.set_ef_search_default(50) # ef should always be > k
 
 # Query dataset, k - number of the closest elements (returns 2 numpy arrays)
 labels, distances = p.knn_query(data, k = 1)
@@ -72,7 +72,7 @@ p.init_index(max_elements=num_elements//2, ef_construction=100, M=16)
 
 # Controlling the recall by setting ef:
 # higher ef leads to better accuracy, but slower search
-p.set_ef(10)
+p.set_ef_search_default(10)
 
 # Set number of threads used during batch search/construction
 # By default using all available cores
@@ -133,7 +133,7 @@ hnsw_index.init_index(max_elements=num_elements, ef_construction=100, M=16)
 
 # Controlling the recall by setting ef:
 # higher ef leads to better accuracy, but slower search
-hnsw_index.set_ef(10)
+hnsw_index.set_ef_search_default(10)
 
 # Set number of threads used during batch search/construction
 # By default using all available cores
@@ -185,7 +185,7 @@ hnsw_index.init_index(max_elements=max_num_elements, ef_construction=200, M=16, 
 
 # Controlling the recall by setting ef:
 # higher ef leads to better accuracy, but slower search
-hnsw_index.set_ef(10)
+hnsw_index.set_ef_search_default(10)
 
 # Set number of threads used during batch search/construction
 # By default using all available cores

--- a/examples/python/EXAMPLES.md
+++ b/examples/python/EXAMPLES.md
@@ -37,7 +37,7 @@ p_copy = pickle.loads(pickle.dumps(p)) # creates a copy of index p using pickle 
 print(f"Parameters passed to constructor:  space={p_copy.space}, dim={p_copy.dim}") 
 print(f"Index construction: M={p_copy.M}, ef_construction={p_copy.ef_construction}")
 print(f"Index size is {p_copy.element_count} and index capacity is {p_copy.max_elements}")
-print(f"Search speed/quality trade-off parameter: ef={p_copy.ef}")
+print(f"Search speed/quality trade-off parameter: ef={p_copy_search_default}")
 ```
 
 An example with updates after serialization/deserialization:

--- a/examples/python/EXAMPLES.md
+++ b/examples/python/EXAMPLES.md
@@ -37,7 +37,7 @@ p_copy = pickle.loads(pickle.dumps(p)) # creates a copy of index p using pickle 
 print(f"Parameters passed to constructor:  space={p_copy.space}, dim={p_copy.dim}") 
 print(f"Index construction: M={p_copy.M}, ef_construction={p_copy.ef_construction}")
 print(f"Index size is {p_copy.element_count} and index capacity is {p_copy.max_elements}")
-print(f"Search speed/quality trade-off parameter: ef={p_copy_search_default}")
+print(f"Search speed/quality trade-off parameter: ef={p_copy.ef_search_default}")
 ```
 
 An example with updates after serialization/deserialization:

--- a/examples/python/example.py
+++ b/examples/python/example.py
@@ -34,7 +34,7 @@ p.init_index(max_elements=num_elements // 2, ef_construction=100, M=16)
 
 # Controlling the recall by setting ef:
 # higher ef leads to better accuracy, but slower search
-p.set_ef(10)
+p.set_ef_search_default(10)
 
 # Set number of threads used during batch search/construction
 # By default using all available cores

--- a/examples/python/example_filter.py
+++ b/examples/python/example_filter.py
@@ -27,7 +27,7 @@ hnsw_index.init_index(max_elements=num_elements, ef_construction=100, M=16)
 
 # Controlling the recall by setting ef:
 # higher ef leads to better accuracy, but slower search
-hnsw_index.set_ef(10)
+hnsw_index.set_ef_search_default(10)
 
 # Set number of threads used during batch search/construction
 # By default using all available cores

--- a/examples/python/example_replace_deleted.py
+++ b/examples/python/example_replace_deleted.py
@@ -36,7 +36,7 @@ hnsw_index.init_index(
 
 # Controlling the recall by setting ef:
 # higher ef leads to better accuracy, but slower search
-hnsw_index.set_ef(10)
+hnsw_index.set_ef_search_default(10)
 
 # Set number of threads used during batch search/construction
 # By default using all available cores

--- a/examples/python/example_search.py
+++ b/examples/python/example_search.py
@@ -42,4 +42,4 @@ print(f"Index construction: M={p_copy.M}, ef_construction={p_copy.ef_constructio
 print(
     f"Index size is {p_copy.element_count} and index capacity is {p_copy.max_elements}"
 )
-print(f"Search speed/quality trade-off parameter: ef={p_copy.ef}")
+print(f"Search speed/quality trade-off parameter: ef={p_copy.ef_search_default}")

--- a/examples/python/example_search.py
+++ b/examples/python/example_search.py
@@ -24,7 +24,7 @@ p.init_index(max_elements=num_elements, ef_construction=200, M=16)
 p.add_items(data, ids)
 
 # Controlling the recall by setting ef:
-p.set_ef(50)  # ef should always be > k
+p.set_ef_search_default(50)  # ef should always be > k
 
 # Query dataset, k - number of the closest elements (returns 2 numpy arrays)
 labels, distances = p.knn_query(data, k=1)

--- a/examples/python/example_serialization.py
+++ b/examples/python/example_serialization.py
@@ -35,7 +35,7 @@ p.init_index(max_elements=num_elements // 2, ef_construction=100, M=16)
 
 # Controlling the recall by setting ef:
 # higher ef leads to better accuracy, but slower search
-p.set_ef(10)
+p.set_ef_search_default(10)
 
 # Set number of threads used during batch search/construction
 # By default using all available cores

--- a/examples/python/pyw_hnswlib.py
+++ b/examples/python/pyw_hnswlib.py
@@ -42,8 +42,8 @@ class Index:
                 start += 1
         self.index.add_items(data=data, ids=np.asarray(int_labels))
 
-    def set_ef(self, ef):
-        self.index.set_ef(ef)
+    def set_ef_search_default(self, ef):
+        self.index.set_ef_search_default(ef)
 
     def load_index(self, path):
         self.index.load_index(path)

--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -103,7 +103,7 @@ namespace hnswlib
         }
 
         std::priority_queue<std::pair<dist_t, labeltype>>
-        searchKnn(const void *query_data, size_t k, BaseFilterFunctor *isIdAllowed = nullptr) const
+        searchKnn(const void *query_data, size_t k, BaseFilterFunctor *isIdAllowed = nullptr, const std::optional<size_t> ef_search = std::nullopt) const
         {
             assert(k <= cur_element_count);
             std::priority_queue<std::pair<dist_t, labeltype>> topResults;

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -1772,12 +1772,12 @@ namespace hnswlib
             if (num_deleted_)
             {
                 top_candidates = searchBaseLayerST<true, true>(
-                    currObj, query_data, std::max(ef_search.value_or(ef_search_default_), k), isIdAllowed);
+                    currObj, query_data, std::max(ef_search, k), isIdAllowed);
             }
             else
             {
                 top_candidates = searchBaseLayerST<false, true>(
-                    currObj, query_data, std::max(ef_search.value_or(ef_search_default_), k), isIdAllowed);
+                    currObj, query_data, std::max(ef_search, k), isIdAllowed);
             }
 
             while (top_candidates.size() > k)

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -1725,11 +1725,11 @@ namespace hnswlib
         searchKnn(const void *query_data, size_t k, BaseFilterFunctor *isIdAllowed = nullptr, const std::optional<size_t> ef_search = std::nullopt) const
         {
 
-            size_t get_ef_search_default()
+            auto get_ef_search_default = [this]()
             {
                 std::shared_lock<std::shared_mutex> lock(ef_search_default_lock_);
                 return ef_search_default_;
-            }
+            };
 
             const std::size_t this_ef_search = ef_search.has_value() ? ef_search.value() : get_ef_search_default();
             std::priority_queue<std::pair<dist_t, labeltype>>

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -122,7 +122,7 @@ static bool AVX512Capable()
 #include <vector>
 #include <iostream>
 #include <string.h>
-
+#include <optional>
 namespace hnswlib
 {
     typedef size_t labeltype;

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -180,7 +180,7 @@ namespace hnswlib
         virtual void addPoint(const void *datapoint, labeltype label, bool replace_deleted = false) = 0;
 
         virtual std::priority_queue<std::pair<dist_t, labeltype>>
-        searchKnn(const void *, size_t, BaseFilterFunctor *isIdAllowed = nullptr) const = 0;
+        searchKnn(const void *, size_t, BaseFilterFunctor *isIdAllowed = nullptr, const std::optional<size_t> ef_search = std::nullopt) const = 0;
 
         // Return k nearest neighbor in the order of closer fist
         virtual std::vector<std::pair<dist_t, labeltype>>

--- a/python_bindings/LazyIndex.py
+++ b/python_bindings/LazyIndex.py
@@ -44,11 +44,11 @@ class LazyIndex(hnswlib.Index):
         else:
             return super().resize_index(size)
 
-    def set_ef(self, ef):
+    def set_ef_search_default(self, ef):
         if self.max_elements == 0:
             self.init_ef_construction = ef
             return
-        super().set_ef(ef)
+        super().set_ef_search_default(ef)
 
     def get_max_elements(self):
         return self.max_elements

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -579,7 +579,7 @@ public:
         assert_true(appr_alg->mult_ == d["mult"].cast<double>(), "Invalid value of mult_ ");
         assert_true(appr_alg->ef_construction_ == d["ef_construction"].cast<size_t>(), "Invalid value of ef_construction_ ");
 
-        appr_alg->ef_search_default_ = d["ef_search_default"].cast<size_t>();
+        assert_true(appr_alg->ef_search_default_ = d["ef_search_default"].cast<size_t>(), "Invalid value of ef_search_default_ ");
 
         assert_true(appr_alg->size_links_per_element_ == d["size_links_per_element"].cast<size_t>(), "Invalid value of size_links_per_element_ ");
 

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -173,7 +173,7 @@ public:
     std::string space_name;
     int dim;
     size_t seed;
-    size_t default_ef;
+    size_t ef_search_default;
 
     bool index_inited;
     bool ep_added;
@@ -207,8 +207,6 @@ public:
         ep_added = true;
         index_inited = false;
         num_threads_default = std::thread::hardware_concurrency();
-
-        default_ef = 10;
     }
 
     ~Index()
@@ -222,6 +220,7 @@ public:
         size_t maxElements,
         size_t M,
         size_t efConstruction,
+        size_t efSearchDefault,
         size_t random_seed,
         bool allow_replace_deleted,
         bool is_persistent_index,
@@ -232,18 +231,19 @@ public:
             throw std::runtime_error("The index is already initiated.");
         }
         cur_l = 0;
-        appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, maxElements, M, efConstruction, random_seed, allow_replace_deleted, normalize, is_persistent_index, persistence_location);
+        appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, maxElements, M, efConstruction, efSearchDefault, random_seed, allow_replace_deleted, normalize, is_persistent_index, persistence_location);
         index_inited = true;
         ep_added = false;
-        appr_alg->ef_ = default_ef;
+        ef_search_default = efSearchDefault;
+        appr_alg->ef_search_default_ = efSearchDefault;
         seed = random_seed;
     }
 
-    void set_ef(size_t ef)
+    void set_ef_search_default(size_t ef_search_default)
     {
-        default_ef = ef;
+        ef_search_default = ef_search_default;
         if (appr_alg)
-            appr_alg->ef_ = ef;
+            appr_alg->ef_search_default_ = ef_search_default;
     }
 
     void set_num_threads(int num_threads)
@@ -456,7 +456,7 @@ public:
             "M"_a = appr_alg->M_,
             "mult"_a = appr_alg->mult_,
             "ef_construction"_a = appr_alg->ef_construction_,
-            "ef"_a = appr_alg->ef_,
+            "ef_search_default"_a = appr_alg->ef_search_default_,
             "has_deletions"_a = (bool)appr_alg->num_deleted_,
             "size_links_per_element"_a = appr_alg->size_links_per_element_,
             "allow_replace_deleted"_a = appr_alg->allow_replace_deleted_,
@@ -506,7 +506,7 @@ public:
             "seed"_a = seed);
 
         if (index_inited == false)
-            return py::dict(**params, "ef"_a = default_ef);
+            return py::dict(**params, "ef_search_default"_a = ef_search_default);
 
         auto ann_params = getAnnData();
 
@@ -535,6 +535,7 @@ public:
                 d["max_elements"].cast<size_t>(),
                 d["M"].cast<size_t>(),
                 d["ef_construction"].cast<size_t>(),
+                d["ef_search_default"].cast<size_t>(),
                 new_index->seed);
             new_index->cur_l = d["cur_element_count"].cast<size_t>();
         }
@@ -542,7 +543,7 @@ public:
         new_index->index_inited = index_inited_;
         new_index->ep_added = d["ep_added"].cast<bool>();
         new_index->num_threads_default = d["num_threads"].cast<int>();
-        new_index->default_ef = d["ef"].cast<size_t>();
+        new_index->ef_search_default = d["ef_search_default"].cast<size_t>();
 
         if (index_inited_)
             new_index->setAnnData(d);
@@ -577,7 +578,7 @@ public:
         assert_true(appr_alg->mult_ == d["mult"].cast<double>(), "Invalid value of mult_ ");
         assert_true(appr_alg->ef_construction_ == d["ef_construction"].cast<size_t>(), "Invalid value of ef_construction_ ");
 
-        appr_alg->ef_ = d["ef"].cast<size_t>();
+        appr_alg->ef_search_default_ = d["ef_search_default"].cast<size_t>();
 
         assert_true(appr_alg->size_links_per_element_ == d["size_links_per_element"].cast<size_t>(), "Invalid value of size_links_per_element_ ");
 
@@ -665,7 +666,8 @@ public:
         py::object input,
         size_t k = 1,
         int num_threads = -1,
-        const std::function<bool(hnswlib::labeltype)> &filter = nullptr)
+        const std::function<bool(hnswlib::labeltype)> &filter = nullptr,
+        const std::optional<size_t> ef_search = std::nullopt)
     {
         py::array_t<dist_t, py::array::c_style | py::array::forcecast> items(input);
         auto buffer = items.request();
@@ -701,7 +703,7 @@ public:
                         (void*)items.data(row), k, p_idFilter);
                     if (result.size() != k)
                         throw std::runtime_error(
-                            "Cannot return the results in a contigious 2D array. Probably ef or M is too small");
+                            "Cannot return the results in a contigious 2D array. Probably ef_search_default or M is too small");
                     for (int i = k - 1; i >= 0; i--) {
                         auto& result_tuple = result.top();
                         data_numpy_d[row * k + i] = result_tuple.first;
@@ -723,7 +725,7 @@ public:
                         (void*)(norm_array.data() + start_idx), k, p_idFilter);
                     if (result.size() != k)
                         throw std::runtime_error(
-                            "Cannot return the results in a contigious 2D array. Probably ef or M is too small");
+                            "Cannot return the results in a contigious 2D array. Probably ef_search_default or M is too small");
                     for (int i = k - 1; i >= 0; i--) {
                         auto& result_tuple = result.top();
                         data_numpy_d[row * k + i] = result_tuple.first;
@@ -900,7 +902,8 @@ public:
     py::object knnQuery_return_numpy(
         py::object input,
         size_t k = 1,
-        const std::function<bool(hnswlib::labeltype)> &filter = nullptr)
+        const std::function<bool(hnswlib::labeltype)> &filter = nullptr,
+        const std::optional<size_t> ef_search = std::nullopt)
     {
         py::array_t<dist_t, py::array::c_style | py::array::forcecast> items(input);
         auto buffer = items.request();
@@ -921,7 +924,7 @@ public:
             for (size_t row = 0; row < rows; row++)
             {
                 std::priority_queue<std::pair<dist_t, hnswlib::labeltype>> result = alg->searchKnn(
-                    (void *)items.data(row), k, p_idFilter);
+                    (void *)items.data(row), k, p_idFilter, ef_search);
                 for (int i = k - 1; i >= 0; i--)
                 {
                     auto &result_tuple = result.top();
@@ -966,6 +969,7 @@ PYBIND11_PLUGIN(hnswlib)
              py::arg("max_elements"),
              py::arg("M") = 16,
              py::arg("ef_construction") = 200,
+             py::arg("ef_search_default") = 10,
              py::arg("random_seed") = 100,
              py::arg("allow_replace_deleted") = false,
              py::arg("is_persistent_index") = false,
@@ -975,7 +979,8 @@ PYBIND11_PLUGIN(hnswlib)
              py::arg("data"),
              py::arg("k") = 1,
              py::arg("num_threads") = -1,
-             py::arg("filter") = py::none())
+             py::arg("filter") = py::none(),
+             py::arg("ef_search") = py::none())
         .def("add_items",
              &Index<float>::addItems,
              py::arg("data"),
@@ -984,7 +989,7 @@ PYBIND11_PLUGIN(hnswlib)
              py::arg("replace_deleted") = false)
         .def("get_items", &Index<float, float>::getDataReturnList, py::arg("ids") = py::none())
         .def("get_ids_list", &Index<float>::getIdsList)
-        .def("set_ef", &Index<float>::set_ef, py::arg("ef"))
+        .def("set_ef_search_default", &Index<float>::set_ef_search_default, py::arg("ef_search_default"))
         .def("set_num_threads", &Index<float>::set_num_threads, py::arg("num_threads"))
         .def("save_index", &Index<float>::saveIndex, py::arg("path_to_index"))
         .def("load_index",
@@ -1004,12 +1009,12 @@ PYBIND11_PLUGIN(hnswlib)
         .def_readonly("space", &Index<float>::space_name)
         .def_readonly("dim", &Index<float>::dim)
         .def_readwrite("num_threads", &Index<float>::num_threads_default)
-        .def_property("ef", [](const Index<float> &index)
-                      { return index.index_inited ? index.appr_alg->ef_ : index.default_ef; }, [](Index<float> &index, const size_t ef_)
+        .def_property("ef_search_default", [](const Index<float> &index)
+                      { return index.index_inited ? index.appr_alg->ef_search_default_ : index.ef_search_default; }, [](Index<float> &index, const size_t ef_search_default_)
                       {
-            index.default_ef = ef_;
+            index.ef_search_default = ef_search_default_;
             if (index.appr_alg)
-              index.appr_alg->ef_ = ef_; })
+              index.appr_alg->ef_search_default_ = ef_search_default_; })
         .def_property_readonly("max_elements", [](const Index<float> &index)
                                { return index.index_inited ? index.appr_alg->max_elements_ : 0; })
         .def_property_readonly("element_count", [](const Index<float> &index)
@@ -1036,7 +1041,7 @@ PYBIND11_PLUGIN(hnswlib)
     py::class_<BFIndex<float>>(m, "BFIndex")
         .def(py::init<const std::string &, const int>(), py::arg("space"), py::arg("dim"))
         .def("init_index", &BFIndex<float>::init_new_index, py::arg("max_elements"))
-        .def("knn_query", &BFIndex<float>::knnQuery_return_numpy, py::arg("data"), py::arg("k") = 1, py::arg("filter") = py::none())
+        .def("knn_query", &BFIndex<float>::knnQuery_return_numpy, py::arg("data"), py::arg("k") = 1, py::arg("filter") = py::none(), py::arg("ef_search") = py::none())
         .def("add_items", &BFIndex<float>::addItems, py::arg("data"), py::arg("ids") = py::none())
         .def("delete_vector", &BFIndex<float>::deleteVector, py::arg("label"))
         .def("save_index", &BFIndex<float>::saveIndex, py::arg("path_to_index"))

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <stdlib.h>
 #include <assert.h>
+#include <optional>
 
 namespace py = pybind11;
 using namespace pybind11::literals; // needed to bring in _a literal

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ class BuildExt(build_ext):
                 opts.append("-fvisibility=hidden")
         elif ct == "msvc":
             opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
-            opts.append("/std::c++17")
+            opts.append("/std:c++latest")
 
         for ext in self.extensions:
             ext.extra_compile_args.extend(opts)

--- a/setup.py
+++ b/setup.py
@@ -93,8 +93,8 @@ class BuildExt(build_ext):
     if sys.platform == "darwin":
         if platform.machine() == "arm64":
             c_opts["unix"].remove("-march=native")
-        c_opts["unix"] += ["-stdlib=libc++", "-mmacosx-version-min=10.7"]
-        link_opts["unix"] += ["-stdlib=libc++", "-mmacosx-version-min=10.7"]
+        c_opts["unix"] += ["-stdlib=libc++", "-mmacosx-version-min=10.12"]
+        link_opts["unix"] += ["-stdlib=libc++", "-mmacosx-version-min=10.12"]
     else:
         c_opts["unix"].append("-fopenmp")
         link_opts["unix"].extend(["-fopenmp", "-pthread"])

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ class BuildExt(build_ext):
                 opts.append("-fvisibility=hidden")
         elif ct == "msvc":
             opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
+            opts.append(cpp_flag(self.compiler))
 
         for ext in self.extensions:
             ext.extra_compile_args.extend(opts)

--- a/setup.py
+++ b/setup.py
@@ -93,8 +93,8 @@ class BuildExt(build_ext):
     if sys.platform == "darwin":
         if platform.machine() == "arm64":
             c_opts["unix"].remove("-march=native")
-        c_opts["unix"] += ["-stdlib=libc++", "-mmacosx-version-min=10.12"]
-        link_opts["unix"] += ["-stdlib=libc++", "-mmacosx-version-min=10.12"]
+        c_opts["unix"] += ["-stdlib=libc++", "-mmacosx-version-min=10.13"]
+        link_opts["unix"] += ["-stdlib=libc++", "-mmacosx-version-min=10.13"]
     else:
         c_opts["unix"].append("-fopenmp")
         link_opts["unix"].extend(["-fopenmp", "-pthread"])

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ class BuildExt(build_ext):
                 opts.append("-fvisibility=hidden")
         elif ct == "msvc":
             opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
-            opts.append(cpp_flag(self.compiler))
+            opts.append("/std::c++17")
 
         for ext in self.extensions:
             ext.extra_compile_args.extend(opts)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import setuptools
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"
 
 include_dirs = [
     pybind11.get_include(),
@@ -59,9 +59,11 @@ def has_flag(compiler, flagname):
 
 
 def cpp_flag(compiler):
-    """Return the -std=c++[11/14] compiler flag.
-    The c++14 is prefered over c++11 (when it is available).
+    """Return the -std=c++[11/14/17] compiler flag.
+    The c++14 is prefered over c++17 (when it is available).
     """
+    if has_flag(compiler, "-std=c++17"):
+        return "-std=c++17"
     if has_flag(compiler, "-std=c++14"):
         return "-std=c++14"
     elif has_flag(compiler, "-std=c++11"):

--- a/tests/cpp/getUnormalized_test.cpp
+++ b/tests/cpp/getUnormalized_test.cpp
@@ -29,7 +29,7 @@ namespace
         }
 
         hnswlib::InnerProductSpace space(d);
-        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, 2 * n, 16, 200, 100, false, true);
+        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, 2 * n, 16, 200, 10, 100, false, true);
 
         for (size_t i = 0; i < n; i++)
         {
@@ -69,7 +69,7 @@ namespace
         }
 
         hnswlib::InnerProductSpace space(d);
-        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, 2 * n, 16, 200, 100, false, true);
+        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, 2 * n, 16, 200, 10, 100, false, true);
 
         for (size_t i = 0; i < n; i++)
         {
@@ -113,7 +113,7 @@ namespace
         }
 
         hnswlib::InnerProductSpace space(d);
-        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, 2 * n, 16, 200, 100, false, true);
+        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, 2 * n, 16, 200, 10, 100, false, true);
 
         for (size_t i = 0; i < n; i++)
         {
@@ -179,7 +179,7 @@ void testResizeUnormalizedData()
     }
 
     hnswlib::InnerProductSpace space(d);
-    hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, n, 16, 200, 100, false, true);
+    hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, n, 16, 200, 10, 100, false, true);
 
     for (size_t i = 0; i < n; i++)
     {

--- a/tests/cpp/multiThread_replace_test.cpp
+++ b/tests/cpp/multiThread_replace_test.cpp
@@ -102,7 +102,7 @@ int main()
     int iter = 0;
     while (iter < 200)
     {
-        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements, 16, 200, 123, true);
+        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements, 16, 200, 100, 123, true);
 
         // add batch1 data
         ParallelFor(0, max_elements, num_threads, [&](size_t row, size_t threadId)

--- a/tests/cpp/persistent_test.cpp
+++ b/tests/cpp/persistent_test.cpp
@@ -34,7 +34,7 @@ namespace
         }
 
         hnswlib::InnerProductSpace space(d);
-        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, 2 * n, 16, 200, 100, false, false, true, ".");
+        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, 2 * n, 16, 200, 10, 100, false, false, true, ".");
 
         for (size_t i = 0; i < n; i++)
         {
@@ -105,7 +105,7 @@ namespace
         }
 
         hnswlib::InnerProductSpace space(d);
-        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, n / 4, 16, 200, 100, false, false, true, ".");
+        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, n / 4, 16, 200, 10, 100, false, false, true, ".");
 
         // Add a quarter of the data
         for (size_t i = 0; i < n / 4; i++)
@@ -189,7 +189,7 @@ namespace
         }
 
         hnswlib::InnerProductSpace space(d);
-        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, n, 16, 200, 100, false, false, true, ".");
+        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, n, 16, 200, 10, 100, false, false, true, ".");
 
         for (size_t i = 0; i < n; i++)
         {
@@ -256,7 +256,7 @@ namespace
         }
 
         hnswlib::InnerProductSpace space(d);
-        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, n, 16, 200, 100, false, false, true, ".");
+        hnswlib::HierarchicalNSW<float> *alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, n, 16, 200, 10, 100, false, false, true, ".");
 
         for (size_t i = 0; i < n; i++)
         {

--- a/tests/cpp/sift_1b.cpp
+++ b/tests/cpp/sift_1b.cpp
@@ -39,6 +39,9 @@ public:
  */
 
 #if defined(_WIN32)
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#define _ENABLE_EXTENDED_ALIGNED_STORAGE
 #include <windows.h>
 #include <psapi.h>
 
@@ -235,7 +238,8 @@ test_vs_recall(
     {
         efs.push_back(i);
     }
-    for (size_t ef : efs) {
+    for (size_t ef : efs)
+    {
         appr_alg.setEfSearchDefault(ef);
         StopW stopw = StopW();
 

--- a/tests/cpp/sift_1b.cpp
+++ b/tests/cpp/sift_1b.cpp
@@ -235,9 +235,8 @@ test_vs_recall(
     {
         efs.push_back(i);
     }
-    for (size_t ef : efs)
-    {
-        appr_alg.setEf(ef);
+    for (size_t ef : efs) {
+        appr_alg.setEfSearchDefault(ef);
         StopW stopw = StopW();
 
         float recall = test_approx(massQ, vecsize, qsize, appr_alg, vecdim, answers, k);

--- a/tests/cpp/sift_test.cpp
+++ b/tests/cpp/sift_test.cpp
@@ -146,9 +146,8 @@ void test_vs_recall(
     /*for (int i = 300; i <600; i += 20) {
         efs.push_back(i);
     }*/
-    for (size_t ef : efs)
-    {
-        appr_alg.setEf(ef);
+    for (size_t ef : efs) {
+        appr_alg.setEfSearchDefault(ef);
         StopW stopw = StopW();
 
         float recall = test_approx(massQ, vecsize, qsize, appr_alg, vecdim, answers, k);
@@ -281,65 +280,65 @@ void sift_test()
     // appr_alg.opt = true;
 
     return;
-    // test_approx(mass, massQ, vecsize, qsize, appr_alg, vecdim, answers);
-    //    //return;
-    //
-    //    cout << appr_alg.maxlevel_ << "\n";
-    //    //CHECK:
-    //    //for (size_t io = 0; io < vecsize; io++) {
-    //    //    if (appr_alg.getExternalLabel(io) != io)
-    //    //        throw new exception("bad!");
-    //    //}
-    //    DISTFUNC<float> fstdistfunc_ = l2space.get_dist_func();
-    ////#pragma omp parallel for
-    //    for (int i = 0; i < vecsize; i++) {
-    //        int *data = (int *)(appr_alg.linkList0_ + i * appr_alg.size_links_per_element0_);
-    //        //cout << "numconn:" << *data<<"\n";
-    //        tableint *datal = (tableint *)(data + 1);
-    //
-    //        std::priority_queue< std::pair< float, tableint >> rez;
-    //        unordered_set <tableint> g;
-    //        for (int j = 0; j < *data; j++) {
-    //            g.insert(datal[j]);
-    //        }
-    //        appr_alg.setEf(400);
-    //        std::priority_queue< std::pair< float, tableint >> closest_elements = appr_alg.searchKnnInternal(appr_alg.getDataByInternalId(i), 17);
-    //        while (closest_elements.size() > 0) {
-    //            if (closest_elements.top().second != i) {
-    //                 g.insert(closest_elements.top().second);
-    //            }
-    //            closest_elements.pop();
-    //        }
-    //
-    //        for (tableint l : g) {
-    //            float other = fstdistfunc_(appr_alg.getDataByInternalId(l), appr_alg.getDataByInternalId(i), l2space.get_dist_func_param());
-    //            rez.emplace(other, l);
-    //        }
-    //        while (rez.size() > 32)
-    //            rez.pop();
-    //        int len = rez.size();
-    //        *data = len;
-    //        // check there are no loop connections created
-    //        for (int j = 0; j < len; j++) {
-    //            datal[j] = rez.top().second;
-    //            if (datal[j] == i)
-    //                throw new exception();
-    //            rez.pop();
-    //        }
-    //
-    //    }
-    //
-    //    //get_knn_quality(massA, vecsize, maxn, appr_alg);
-    //    test_vs_recall( massQ, vecsize, qsize, appr_alg, vecdim, answers, k);
-    //    /*test_vs_recall( massQ, vecsize, qsize, appr_alg, vecdim, answers, k);
-    //    test_vs_recall( massQ, vecsize, qsize, appr_alg, vecdim, answers, k);
-    //    test_vs_recall( massQ, vecsize, qsize, appr_alg, vecdim, answers, k);*/
-    //
-    //
-    //
-    //
-    //
-    //    /*for(int i=0;i<1000;i++)
-    //        cout << mass[i] << "\n";*/
-    //        //("11", std::ios::binary);
+    //test_approx(mass, massQ, vecsize, qsize, appr_alg, vecdim, answers);
+//    //return;
+//
+//    cout << appr_alg.maxlevel_ << "\n";
+//    //CHECK:
+//    //for (size_t io = 0; io < vecsize; io++) {
+//    //    if (appr_alg.getExternalLabel(io) != io)
+//    //        throw new exception("bad!");
+//    //}
+//    DISTFUNC<float> fstdistfunc_ = l2space.get_dist_func();
+////#pragma omp parallel for
+//    for (int i = 0; i < vecsize; i++) {
+//        int *data = (int *)(appr_alg.linkList0_ + i * appr_alg.size_links_per_element0_);
+//        //cout << "numconn:" << *data<<"\n";
+//        tableint *datal = (tableint *)(data + 1);
+//
+//        std::priority_queue< std::pair< float, tableint >> rez;
+//        unordered_set <tableint> g;
+//        for (int j = 0; j < *data; j++) {
+//            g.insert(datal[j]);
+//        }
+//        appr_alg.setEfSearchDefault(400);
+//        std::priority_queue< std::pair< float, tableint >> closest_elements = appr_alg.searchKnnInternal(appr_alg.getDataByInternalId(i), 17);
+//        while (closest_elements.size() > 0) {
+//            if (closest_elements.top().second != i) {
+//                 g.insert(closest_elements.top().second);
+//            }
+//            closest_elements.pop();
+//        }
+//
+//        for (tableint l : g) {
+//            float other = fstdistfunc_(appr_alg.getDataByInternalId(l), appr_alg.getDataByInternalId(i), l2space.get_dist_func_param());
+//            rez.emplace(other, l);
+//        }
+//        while (rez.size() > 32)
+//            rez.pop();
+//        int len = rez.size();
+//        *data = len;
+//        // check there are no loop connections created
+//        for (int j = 0; j < len; j++) {
+//            datal[j] = rez.top().second;
+//            if (datal[j] == i)
+//                throw new exception();
+//            rez.pop();
+//        }
+//
+//    }
+//
+//    //get_knn_quality(massA, vecsize, maxn, appr_alg);
+//    test_vs_recall( massQ, vecsize, qsize, appr_alg, vecdim, answers, k);
+//    /*test_vs_recall( massQ, vecsize, qsize, appr_alg, vecdim, answers, k);
+//    test_vs_recall( massQ, vecsize, qsize, appr_alg, vecdim, answers, k);
+//    test_vs_recall( massQ, vecsize, qsize, appr_alg, vecdim, answers, k);*/
+//
+//
+//
+//
+//
+//    /*for(int i=0;i<1000;i++)
+//        cout << mass[i] << "\n";*/
+//        //("11", std::ios::binary);
 }

--- a/tests/cpp/updates_test.cpp
+++ b/tests/cpp/updates_test.cpp
@@ -167,9 +167,8 @@ test_vs_recall(
     std::cout << "ef\trecall\ttime\thops\tdistcomp\n";
 
     bool test_passed = false;
-    for (size_t ef : efs)
-    {
-        appr_alg.setEf(ef);
+    for (size_t ef : efs) {
+        appr_alg.setEfSearchDefault(ef);
 
         appr_alg.metric_hops = 0;
         appr_alg.metric_distance_computations = 0;

--- a/tests/python/bindings_test.py
+++ b/tests/python/bindings_test.py
@@ -29,7 +29,7 @@ class RandomSelfTestCase(unittest.TestCase):
 
         # Controlling the recall by setting ef:
         # higher ef leads to better accuracy, but slower search
-        p.set_ef(10)
+        p.set_ef_search_default(10)
 
         p.set_num_threads(4)  # by default using all available cores
 

--- a/tests/python/bindings_test_filter.py
+++ b/tests/python/bindings_test_filter.py
@@ -33,7 +33,7 @@ class RandomSelfTestCase(unittest.TestCase):
 
         # Controlling the recall by setting ef:
         # higher ef leads to better accuracy, but slower search
-        hnsw_index.set_ef(10)
+        hnsw_index.set_ef_search_default(10)
 
         hnsw_index.set_num_threads(4)  # by default using all available cores
 

--- a/tests/python/bindings_test_getdata.py
+++ b/tests/python/bindings_test_getdata.py
@@ -34,7 +34,7 @@ class RandomSelfTestCase(unittest.TestCase):
 
             # Controlling the recall by setting ef:
             # higher ef leads to better accuracy, but slower search
-            p.set_ef(100)
+            p.set_ef_search_default(100)
 
             p.set_num_threads(4)  # by default using all available cores
 

--- a/tests/python/bindings_test_labels.py
+++ b/tests/python/bindings_test_labels.py
@@ -35,7 +35,7 @@ class RandomSelfTestCase(unittest.TestCase):
 
             # Controlling the recall by setting ef:
             # higher ef leads to better accuracy, but slower search
-            p.set_ef(100)
+            p.set_ef_search_default(100)
 
             p.set_num_threads(4)  # by default using all available cores
 
@@ -77,7 +77,7 @@ class RandomSelfTestCase(unittest.TestCase):
 
             print("\nLoading index from '%s'\n" % index_path)
             p.load_index(index_path)
-            p.set_ef(100)
+            p.set_ef_search_default(100)
 
             print("Adding the second batch of %d elements" % (len(data2)))
             p.add_items(data2)
@@ -126,7 +126,7 @@ class RandomSelfTestCase(unittest.TestCase):
             p.save_index(del_index_path)
             p = hnswlib.Index(space="l2", dim=dim)
             p.load_index(del_index_path)
-            p.set_ef(100)
+            p.set_ef_search_default(100)
 
             labels1_after, _ = p.knn_query(data1, k=1)
             for la in labels1_after:

--- a/tests/python/bindings_test_metadata.py
+++ b/tests/python/bindings_test_metadata.py
@@ -28,7 +28,7 @@ class RandomSelfTestCase(unittest.TestCase):
 
         # Controlling the recall by setting ef:
         # higher ef leads to better accuracy, but slower search
-        p.set_ef(100)
+        p.set_ef_search_default(100)
 
         p.set_num_threads(4)  # by default using all available cores
 

--- a/tests/python/bindings_test_pickle.py
+++ b/tests/python/bindings_test_pickle.py
@@ -98,8 +98,8 @@ def test_space_main(self, space, dim):
         max_elements=self.num_elements, ef_construction=self.ef_construction, M=self.M
     )
 
-    p.ef = self.ef
-    p0.ef = self.ef
+    p.ef_search_default = self.ef_search_default
+    p0.ef_search_default = self.ef_search_default
 
     p1 = pickle.loads(pickle.dumps(p))  # pickle Index before adding items
 
@@ -171,10 +171,18 @@ def test_space_main(self, space, dim):
     )
 
     # Check ef parameter value
-    self.assertEqual(p.ef, self.ef, "incorrect value of p.ef")
-    self.assertEqual(p0.ef, self.ef, "incorrect value of p0.ef")
-    self.assertEqual(p2.ef, self.ef, "incorrect value of p2.ef")
-    self.assertEqual(p1.ef, self.ef, "incorrect value of p1.ef")
+    self.assertEqual(
+        p.ef_search_default, self.ef_search_default, "incorrect value of p.ef"
+    )
+    self.assertEqual(
+        p0.ef_search_default, self.ef_search_default, "incorrect value of p0.ef"
+    )
+    self.assertEqual(
+        p2.ef_search_default, self.ef_search_default, "incorrect value of p2.ef"
+    )
+    self.assertEqual(
+        p1.ef_search_default, self.ef_search_default, "incorrect value of p1.ef"
+    )
 
     # Check M parameter value
     self.assertEqual(p.M, self.M, "incorrect value of p.M")
@@ -207,7 +215,7 @@ class PickleUnitTests(unittest.TestCase):
     def setUp(self):
         self.ef_construction = 200
         self.M = 32
-        self.ef = 400
+        self.ef_search_default = 400
 
         self.num_elements = 1000
         self.num_test_elements = 100

--- a/tests/python/bindings_test_recall.py
+++ b/tests/python/bindings_test_recall.py
@@ -38,7 +38,7 @@ class RandomSelfTestCase(unittest.TestCase):
 
         # Controlling the recall for hnsw by setting ef:
         # higher ef leads to better accuracy, but slower search
-        hnsw_index.set_ef(200)
+        hnsw_index.set_ef_search_default(200)
 
         # Set number of threads used during batch search/construction in hnsw
         # By default using all available cores

--- a/tests/python/bindings_test_replace.py
+++ b/tests/python/bindings_test_replace.py
@@ -51,7 +51,7 @@ class RandomSelfTestCase(unittest.TestCase):
             allow_replace_deleted=True,
         )
 
-        hnsw_index.set_ef(100)
+        hnsw_index.set_ef_search_default(100)
         hnsw_index.set_num_threads(4)
 
         # Add batch 1 and 2
@@ -213,9 +213,9 @@ class RandomSelfTestCase(unittest.TestCase):
         bf_index = hnswlib.BFIndex(space="l2", dim=dim)
         bf_index.init_index(max_elements=max_num_elements)
 
-        hnsw_index_no_replace.set_ef(100)
+        hnsw_index_no_replace.set_ef_search_default(100)
         hnsw_index_no_replace.set_num_threads(50)
-        hnsw_index_with_replace.set_ef(100)
+        hnsw_index_with_replace.set_ef_search_default(100)
         hnsw_index_with_replace.set_num_threads(50)
 
         # Add data

--- a/tests/python/bindings_test_resize.py
+++ b/tests/python/bindings_test_resize.py
@@ -34,7 +34,7 @@ class RandomSelfTestCase(unittest.TestCase):
 
             # Controlling the recall by setting ef:
             # higher ef leads to better accuracy, but slower search
-            p.set_ef(20)
+            p.set_ef_search_default(20)
 
             p.set_num_threads(idx % 8)  # by default using all available cores
 

--- a/tests/python/bindings_test_spaces.py
+++ b/tests/python/bindings_test_spaces.py
@@ -36,7 +36,7 @@ class RandomSelfTestCase(unittest.TestCase):
                     p = hnswlib.Index(space=space, dim=dim)
                     p.init_index(max_elements=5, ef_construction=100, M=16)
 
-                    p.set_ef(10)
+                    p.set_ef_search_default(10)
 
                     p.add_items(data2)
 

--- a/tests/python/bindings_test_stress_mt_replace.py
+++ b/tests/python/bindings_test_stress_mt_replace.py
@@ -38,7 +38,7 @@ class RandomSelfTestCase(unittest.TestCase):
                 allow_replace_deleted=True,
             )
 
-            hnsw_index.set_ef(100)
+            hnsw_index.set_ef_search_default(100)
             hnsw_index.set_num_threads(50)
 
             # Add batch 1 and 2

--- a/tests/python/speedtest.py
+++ b/tests/python/speedtest.py
@@ -6,13 +6,13 @@ import argparse
 
 # Use nargs to specify how many arguments an option should take.
 ap = argparse.ArgumentParser()
-ap.add_argument('-d')
-ap.add_argument('-n')
-ap.add_argument('-t')
+ap.add_argument("-d")
+ap.add_argument("-n")
+ap.add_argument("-t")
 args = ap.parse_args()
 dim = int(args.d)
 name = args.n
-threads=int(args.t)
+threads = int(args.t)
 num_elements = 400000
 
 # Generating sample data
@@ -22,7 +22,7 @@ data = np.float32(np.random.random((num_elements, dim)))
 
 # index_path=f'speed_index{dim}.bin'
 # Declaring index
-p = hnswlib.Index(space='l2', dim=dim)  # possible options are l2, cosine or ip
+p = hnswlib.Index(space="l2", dim=dim)  # possible options are l2, cosine or ip
 
 # if not os.path.isfile(index_path) :
 
@@ -30,36 +30,35 @@ p.init_index(max_elements=num_elements, ef_construction=60, M=16)
 
 # Controlling the recall by setting ef:
 # higher ef leads to better accuracy, but slower search
-p.set_ef(10)
+p.set_ef_search_default(10)
 
 # Set number of threads used during batch search/construction
 # By default using all available cores
 p.set_num_threads(64)
-t0=time.time()
+t0 = time.time()
 p.add_items(data)
-construction_time=time.time()-t0
+construction_time = time.time() - t0
 # Serializing and deleting the index:
 
 # print("Saving index to '%s'" % index_path)
 # p.save_index(index_path)
 p.set_num_threads(threads)
-times=[]
+times = []
 time.sleep(1)
-p.set_ef(15)
+p.set_ef_search_default(15)
 for _ in range(1):
     # p.load_index(index_path)
     for _ in range(3):
-        t0=time.time()
-        qdata=data[:5000*threads]
+        t0 = time.time()
+        qdata = data[: 5000 * threads]
         labels, distances = p.knn_query(qdata, k=1)
-        tt=time.time()-t0
+        tt = time.time() - t0
         times.append(tt)
-        recall=np.sum(labels.reshape(-1)==np.arange(len(qdata)))/len(qdata)
-        print(f"{tt} seconds, recall= {recall}")    
-        
-str_out=f"{np.mean(times)}, {np.median(times)}, {np.std(times)}, {construction_time}, {recall}, {name}"
-print(str_out)
-with open (f"log2_{dim}_t{threads}.txt","a") as f:
-    f.write(str_out+"\n")
-    f.flush()
+        recall = np.sum(labels.reshape(-1) == np.arange(len(qdata))) / len(qdata)
+        print(f"{tt} seconds, recall= {recall}")
 
+str_out = f"{np.mean(times)}, {np.median(times)}, {np.std(times)}, {construction_time}, {recall}, {name}"
+print(str_out)
+with open(f"log2_{dim}_t{threads}.txt", "a") as f:
+    f.write(str_out + "\n")
+    f.flush()


### PR DESCRIPTION
`ef_search` is a parameter consumed at query time which determines how many edges of the HNSW graph are traversed to find approximate nearest neighbors. Setting this hyperparameter allows HNSW to trade recall for speed at query time. 

The way this was implemented by HNSWlib had some bad design decisions. It was a property of each index, changed by calling `set_ef` on the index; besides being cumbersome, it also creates a data race in concurrent execution where multiple threads want to execute queries with different ef_search. 

Additionally, it was not written out with the index, and when the index was loaded again, it was set to `10`, creating an unncessary footgun. 

This PR fixes all of the above. It:
- changes the index parameter name to `ef_search_default_` to make it clear what this is for, and renames the function signatures setting it accordingly.

- adds a shared mutex which is locked when writing, but allows parallel reading.

- stores the default when the index is written out, and reads it when it's loaded

- adds an argument to the query path allowing each query to set it independently - this is passed by value so it's on the  stack of the function call, rather than on the heap. if it's not passed, we read the index default

- updates all tests and examples 

Making this work required us to go up to C++ 17 and change the mac OS target to be 10.12 or later. These are both ancient, and we compile this for our users anyway. 