### PR TITLE
Lock numpy to < 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "numpy>=1.10.0",
+    "numpy>=1.10.0,<2.0.0",
     "pybind11>=2.0",
 ]
 


### PR DESCRIPTION
This PR reproduces the fix seen here:
- https://github.com/chroma-core/chroma/pull/2360

This PR fixes a problem detailed in these issues:
- https://github.com/amikos-tech/chromadb-chart/issues/55
- https://github.com/chroma-core/chroma/issues/2358