### PR TITLE
[BUG]  Fix an off-by-one.

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -1835,7 +1835,7 @@ namespace hnswlib
                     std::unordered_set<tableint> s;
                     for (int j = 0; j < size; j++)
                     {
-                        if (data[j] < 0 || data[j] >= cur_element_count || data[j] == i)
+                        if (data[j] <= 0 || data[j] >= cur_element_count || data[j] == i)
                             throw std::runtime_error("HNSW Integrity failure: invalid neighbor index");
                         inbound_connections_num[data[j]]++;
                         s.insert(data[j]);


### PR DESCRIPTION
When changing from assertions to exceptions we introduced a change in
behavior.

```
    assert(data[j] > 0);
```

became

```
    if (data[j] < 0 || ...)
```

This matches the changes before Monday to check <= 0.
