### PR TITLE
Add license to PyPI classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,4 +127,8 @@ setup(
     install_requires=["numpy"],
     cmdclass={"build_ext": BuildExt},
     zip_safe=False,
+    license='Apache-2.0',
+    classifiers=[
+        'License :: OSI Approved :: Apache Software License',
+    ],
 )


### PR DESCRIPTION
Adds [PyPI project classifiers](https://pypi.org/classifiers/)
Classifiers are used to add information to the classifiers panel in PyPI. Example from [NumPy](https://pypi.org/project/numpy/):

![image](https://github.com/user-attachments/assets/c3ba0d19-cd8b-4482-b81e-22ab35fc432e)


The reason that it is very important for this information to be present is that in an enterprise environment, security tools like [Sonatype Nexus IQ](https://help.sonatype.com/iqserver) are used to manage open source software risk. Nexus IQ specifically can be configured to [classify packages according to their license](https://help.sonatype.com/iqserver/managing/policy-management/license-threat-groups). This prevents developers from inadvertently using licenses like [GNU General Public License v2.0](https://www.tldrlegal.com/license/gnu-general-public-license-v2) without realizing that they may be legally obligated to make their entire project open source.

My understanding is that Nexus IQ uses the classifiers panel to determine a project's license.
Because chroma-hnswlib does not currently have a classifiers panel, Nexus cannot determine the license and treats it as a high-risk package.
![image](https://github.com/user-attachments/assets/ef5bacdd-0cfa-483d-af44-b02cd045d881)

By adding classifiers, chroma-hnswlib will have increased availability within enterprise environments.
