### PR TITLE
Revert "[ENH]: Enable integrity checking during hnsw load"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "hnswlib"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "cc",
  "rand",

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -94,8 +94,8 @@ public:
       throw std::runtime_error("Index already inited");
     }
     appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, path_to_index, false, max_elements, allow_replace_deleted, normalize, is_persistent_index);
-
-    appr_alg->checkIntegrity();
+    // TODO(rescrv,sicheng): check integrity
+    // appr_alg->checkIntegrity();
     index_inited = true;
   }
 
@@ -120,8 +120,8 @@ public:
     appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, header_str.c_str(), data_str.c_str(), 
                                                     index_str.c_str(), deleted_str.c_str(), 
                                                     false, max_elements, allow_replace_deleted, normalize);
-
-    appr_alg->checkIntegrity();
+    // TODO(rescrv,sicheng): check integrity
+    // appr_alg->checkIntegrity();
     index_inited = true;
   }
 


### PR DESCRIPTION
Reverts chroma-core/hnswlib#43

The `Cargo.lock` file was never updated to pull this patch in and now that it's enabled it's causing problems.